### PR TITLE
Fix wrong argument type passed to `LogicException` constructor

### DIFF
--- a/src/Parameters/ParameterReflection.php
+++ b/src/Parameters/ParameterReflection.php
@@ -216,8 +216,11 @@ final class ParameterReflection
         try {
             return $reflection->getDefaultValue();
         } catch (ReflectionException $exception) {
-            throw new LogicException('Failed to get parameter default value. This should never happen.',
-                $exception);
+            throw new LogicException(
+                'Failed to get parameter default value. This should never happen.',
+                0,
+                $exception
+            );
         }
     }
 


### PR DESCRIPTION
The second argument is `$code`. The previous exception is accepted with the third argument.