### PR TITLE
Fix for PHP 8.4: implicitly nullable type in TypeReflection::__construct()

### DIFF
--- a/src/Parameters/TypeReflection.php
+++ b/src/Parameters/TypeReflection.php
@@ -27,7 +27,7 @@ final class TypeReflection
      * @param string|null $class Class name this parameter type is used in.
      *                           Necessary for relative `self` and `parent` type hints.
      */
-    public function __construct(string $type, string $class = null)
+    public function __construct(string $type, ?string $class = null)
     {
         if ($type === 'self' && empty($class)) {
             throw new InvalidArgumentException('Type `self` can only be used inside classes.');


### PR DESCRIPTION
Fixes the deprecation warning:
`Technically\CallableReflection\Parameters\TypeReflection::__construct(): Implicitly marking parameter $class as nullable is deprecated, the explicit nullable type must be used instead`